### PR TITLE
Pin pygit2 version to 0.22.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Paul Wellner Bou "<paul@wellnerbou.de>"
 
 RUN apt-get update && apt-get install -y \
         vim less git-core python-dev python-pip libgit2-dev gawk libffi-dev npm net-tools
-RUN pip install pygit2
+RUN pip install pygit2==0.22.1
 RUN pip install flask
 
 ENV DATE 2015-06-02


### PR DESCRIPTION
Pygit2 has newer versions on pip which are incompatible with the libgit2-dev version 0.22 which is installed.  This change fixes the dockerfile so that it pins pygit2 to version 0.22.1 which is compatible.